### PR TITLE
Fix - Failed to execute 'removeChild' on 'Node'

### DIFF
--- a/lib/on-resize.js
+++ b/lib/on-resize.js
@@ -76,7 +76,7 @@ const initialize = (el) => {
       if (detector.elWasStaticPosition) el.style.position = ""
       // Event handlers will be automatically removed.
       // http://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory
-      el.removeChild(objEl)
+      if (el.contains(objEl)) el.removeChild(objEl);
     }
 
     el.appendChild(objEl)


### PR DESCRIPTION
https://github.com/littlebits/react-popover/issues/53
@GabiGrin 